### PR TITLE
Updated to compile with gcc (GCC) 6.1.1 20160707

### DIFF
--- a/src/BinFile.cpp
+++ b/src/BinFile.cpp
@@ -101,7 +101,7 @@ bool BinFile::replace_image(string tag, string filename)
     }
     _file.open(_filename.c_str(), ios::in|ios::out|ios::binary);
     if (_file.fail()) {
-        cerr << "Failed opening '" << _file << "' for writing" << endl;
+        cerr << "Failed opening '" << _filename.c_str() << "' for writing" << endl;
         return false;
     }
 

--- a/src/BinImage.cpp
+++ b/src/BinImage.cpp
@@ -175,7 +175,7 @@ bool BinImage::set_data_from_png(string filename)
 
     // check whether the PNG specifications are met
     bool unsupported = false;
-    long unsigned int width, height;
+    unsigned int width, height;
     int depth, type, interlaceType, compressionType, filterMethod;
 
     png_get_IHDR(pngStruct, pngInfo, &width, &height,


### PR DESCRIPTION
I had to make two minor changes to get moto-bootlogo to compile on gcc (GCC) 6.1.1 20160707 x86_64 on Linux.
