### PR TITLE
Parse header size as 16-bit value

### DIFF
--- a/src/BinFile.cpp
+++ b/src/BinFile.cpp
@@ -186,7 +186,7 @@ void BinFile::_parse_header(void)
 
     // next byte contains the header size
     _file.read(bytes, 2);
-    uint8_t size = (uint8_t)bytes[0];
+    uint16_t size = (uint8_t)bytes[0] + ((uint8_t)bytes[1] << 8);
     if (_file.fail() || !size) {
         cerr << "Header is empty" << endl;
         return;


### PR DESCRIPTION
It seems the header may be longer than 255 bytes on some devices. With this patch I was able to extra all images from the file.