### PR TITLE
move linked library to end of compile options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LFLAGS = -Wall $(DEBUG) -lpng
 all: build
 
 build: $(OBJS)
-	$(CC) $(LFLAGS) $(OBJS) -o build/moto-bootlogo
+	$(CC) $(OBJS) -o build/moto-bootlogo $(LFLAGS)
 
 build/main.o: src/main.cpp
 	$(CC) $(CFLAGS) -o build/main.o src/main.cpp


### PR DESCRIPTION
the reason is explained in https://stackoverflow.com/q/45135/7010943 . The short version being: linker moves left to right to resolve symbols, a linked library that code later depends on will then not be searched again and `undefined symbol` messages be shown. This is the reason for putting `-lpng` at the end.

With this change I can successfully compile with gcc 10.2.1. Thank you for the util and a nicer boot screen.